### PR TITLE
feat: support flux measurements

### DIFF
--- a/model/app.py
+++ b/model/app.py
@@ -449,25 +449,31 @@ class Response(object):
         self.message = message
         self.method_name = message.get(SIMULATION_METHOD, 'fba')
         self.cache = cache
-        try:
-            if self.method_name in {'fva', 'pfba-fva'}:
+        if self.method_name in {'fva', 'pfba-fva'}:
+            try:
                 solution = self.solve_fva()
+            except OptimizationError:
+                logger.info('infeasible model for fva')
+                self.flux = {}
+                self.growth = 0.0
+            else:
                 self.flux = solution.data_frame.T.to_dict()
                 self.growth = self.flux[MODEL_GROWTH_RATE[model.id]]['upper_bound']
-            else:
+        else:
+            try:
                 solution = self.solve()
+            except OptimizationError:
+                logger.info('infeasible model, returning measured fluxes only')
+                changes = model.notes['changes']
+                self.flux = {}
+                self.growth = 0.0
+                if 'measured' in changes:
+                    ids_measured_reactions = set(rxn['id'] for rxn in changes['measured']['reactions'])
+                    self.flux = dict((rxn.id, (rxn.upper_bound + rxn.lower_bound) / 2)
+                                     for rxn in model.reactions if rxn.id in ids_measured_reactions)
+            else:
                 self.flux = solution.fluxes
                 self.growth = self.flux[MODEL_GROWTH_RATE[model.id]]
-        except OptimizationError:
-            # id model is infeasible, return the average measured fluxes only
-            logger.info('infeasible model, returning measured fluxes only')
-            changes = model.notes['changes']
-            self.flux = {}
-            self.growth = 0.0
-            if 'measured' in changes:
-                ids_measured_reactions = set(rxn['id'] for rxn in changes['measured']['reactions'])
-                self.flux = dict((rxn.id, (rxn.upper_bound + rxn.lower_bound) / 2)
-                                 for rxn in model.reactions if rxn.id in ids_measured_reactions)
 
     def solve_fva(self):
         fva_reactions = None
@@ -576,8 +582,7 @@ def apply_additions(model, changes):
 
 def apply_measurements(model, changes):
     for rxn in changes['reactions']:
-        model.reactions.get_by_id(rxn['id']).lower_bound = rxn['lower_bound']
-        model.reactions.get_by_id(rxn['id']).upper_bound = rxn['upper_bound']
+        model.reactions.get_by_id(rxn['id']).change_bounds(lb=rxn['lower_bound'], ub=rxn['upper_bound'])
     return model
 
 

--- a/model/app.py
+++ b/model/app.py
@@ -98,6 +98,10 @@ EMPTY_CHANGES = {
     'removed': {
         'genes': [],
         'reactions': [],
+    },
+    'measured': {
+        'genes': [],
+        'reactions': []
     }
 }
 
@@ -369,7 +373,8 @@ def fix_measurements_ids(measurements):
         'chebi:42758': 'chebi:12965',
     }
     for value in measurements:
-        if value['id'] in IDS:
+        if 'id' in value and value['id'] in IDS:
+            # id is to be interpreted as compound_id
             value['id'] = IDS[value['id']]
     return measurements
 
@@ -454,8 +459,15 @@ class Response(object):
                 self.flux = solution.fluxes
                 self.growth = self.flux[MODEL_GROWTH_RATE[model.id]]
         except OptimizationError:
+            # id model is infeasible, return the average measured fluxes only
+            logger.info('infeasible model, returning measured fluxes only')
+            changes = model.notes['changes']
             self.flux = {}
             self.growth = 0.0
+            if 'measured' in changes:
+                ids_measured_reactions = set(rxn['id'] for rxn in changes['measured']['reactions'])
+                self.flux = dict((rxn.id, (rxn.upper_bound + rxn.lower_bound) / 2)
+                                 for rxn in model.reactions if rxn.id in ids_measured_reactions)
 
     def solve_fva(self):
         fva_reactions = None
@@ -552,12 +564,20 @@ def restore_changes(model, changes):
     logger.info('Changes to restore: {}'.format(changes))
     model = apply_additions(model, changes['added'])
     model = apply_removals(model, changes['removed'])
+    model = apply_measurements(model, changes['measured'])
     return model
 
 
 def apply_additions(model, changes):
     model = add_metabolites(model, changes['metabolites'])
     model = add_reactions(model, changes['reactions'])
+    return model
+
+
+def apply_measurements(model, changes):
+    for rxn in changes['reactions']:
+        model.reactions.get_by_id(rxn['id']).lower_bound = rxn['lower_bound']
+        model.reactions.get_by_id(rxn['id']).upper_bound = rxn['upper_bound']
     return model
 
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -2,17 +2,19 @@ import aiohttp
 import pytest
 import requests
 
-MESSAGE_FLUXES = {'to-return': ['fluxes'], 'measurements': [
-    {'unit': 'mmol', 'name': 'aldehydo-D-glucose', 'id': 'chebi:42758', 'measurements': [-9.0]},
-    {'unit': 'mmol', 'name': 'ethanol', 'id': 'chebi:16236', 'measurements': [5.0, 4.8, 5.2, 4.9]}]}
+MEASUREMENTS = [{'unit': 'mmol', 'name': 'aldehydo-D-glucose', 'id': 'chebi:42758', 'measurements': [-9.0]},
+                {'unit': 'mmol', 'name': 'ethanol', 'id': 'chebi:16236', 'measurements': [5.0, 4.8, 5.2, 4.9]},
+                {'reaction_id': 'PFK', 'measurements': [5, 5]}]
+MESSAGE_FLUXES = {'to-return': ['fluxes'], 'measurements': MEASUREMENTS}
+MESSAGE_FLUXES_INFEASIBLE = {'to-return': ['fluxes'], 'measurements': [
+    {'reaction_id': 'ATPM', 'measurements': [100, 100]}]}
 MESSAGE_TMY_FLUXES = {'to-return': ['fluxes', 'tmy'], 'objectives': ['chebi:17790'], 'request-id': 'requestid'}
 MESSAGE_MODIFY = {
     'simulation-method': 'pfba',
     'to-return': ['tmy', 'fluxes', 'model'],
     'objectives': ['chebi:17790'],
     'genotype-changes': ['+Aac', '-pta'],
-    'measurements': [{'unit': 'mmol', 'name': 'aldehydo-D-glucose', 'id': 'chebi:42758', 'measurements': [-9.0]},
-                     {'unit': 'mmol', 'name': 'ethanol', 'id': 'chebi:16236', 'measurements': [5.0, 4.8, 5.2, 4.9]}],
+    'measurements': MEASUREMENTS,
 }
 
 URL = 'http://localhost:8000/models/'
@@ -32,12 +34,15 @@ def test_http():
         assert set(response.json().keys()) == set(message['to-return'] + ['model-id'])
         assert response.json()['fluxes']['EX_glc__D_e'] == -9.0
         assert abs(response.json()['fluxes']['EX_etoh_e'] - 4.64) < 0.001  # lower bound
+        assert response.json()['fluxes']['PFK'] == 5
         if query == 'modify':
             changes = response.json()['model']['notes']['changes']
             assert 'PTA2' in {rxn['id'] for rxn in changes['removed']['reactions']}
-            assert 'EX_etoh_e' in {rxn['id'] for rxn in changes['added']['reactions']}
+            assert 'EX_etoh_e' in {rxn['id'] for rxn in changes['measured']['reactions']}
+            assert 'PFK' in {rxn['id'] for rxn in changes['measured']['reactions']}
             assert 'b2297' in {rxn['id'] for rxn in changes['removed']['genes']}
-
+    response = requests.post(URL + 'iJO1366', json={'message': MESSAGE_FLUXES_INFEASIBLE})
+    assert response.json()['fluxes']['ATPM'] == 100
     response = requests.post(URL + 'wrong_id', json={'message': {}})
     assert response.status_code == 404
     response = requests.post(URL + 'iJO1366', json={})

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -2,12 +2,14 @@ import aiohttp
 import pytest
 import requests
 
-MEASUREMENTS = [{'unit': 'mmol', 'name': 'aldehydo-D-glucose', 'id': 'chebi:42758', 'measurements': [-9.0]},
-                {'unit': 'mmol', 'name': 'ethanol', 'id': 'chebi:16236', 'measurements': [5.0, 4.8, 5.2, 4.9]},
-                {'reaction_id': 'PFK', 'measurements': [5, 5]}]
+MEASUREMENTS = [{'unit': 'mmol', 'name': 'aldehydo-D-glucose', 'id': 'chebi:42758', 'measurements': [-9.0],
+                 'type': 'compound'},
+                {'unit': 'mmol', 'name': 'ethanol', 'id': 'chebi:16236', 'measurements': [5.0, 4.8, 5.2, 4.9],
+                 'type': 'compound'},
+                {'id': 'PFK', 'measurements': [5, 5], 'type': 'reaction'}]
 MESSAGE_FLUXES = {'to-return': ['fluxes'], 'measurements': MEASUREMENTS}
 MESSAGE_FLUXES_INFEASIBLE = {'to-return': ['fluxes'], 'measurements': [
-    {'reaction_id': 'ATPM', 'measurements': [100, 100]}]}
+    {'id': 'ATPM', 'measurements': [100, 100], 'type': 'reaction'}]}
 MESSAGE_TMY_FLUXES = {'to-return': ['fluxes', 'tmy'], 'objectives': ['chebi:17790'], 'request-id': 'requestid'}
 MESSAGE_MODIFY = {
     'simulation-method': 'pfba',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,8 +20,9 @@ async def test_modify_model():
         'objectives': ['chebi:17790'],
         'genotype-changes': ['+Aac'],
         'medium': [{'id': 'chebi:44080', 'concentration': 0.01}],
-        'measurements': [{'id': 'chebi:44080', 'measurements': [-15, -11, -14, -12], 'unit': 'mg', 'name': 'glucose'},
-                         {'reaction_id': 'PFK', 'measurements': [5, 5, 5, 5]}],
+        'measurements': [{'id': 'chebi:44080', 'measurements': [-15, -11, -14, -12], 'unit': 'mg', 'name': 'glucose',
+                          'type': 'compound'},
+                         {'id': 'PFK', 'measurements': [5, 5, 5, 5], 'type': 'reaction'}],
         'reactions-knockout': ['GLUDy', '3HAD160'],
     }
     assert await modify_model(message, (await restore_model('iJO1366')).copy())
@@ -57,10 +58,11 @@ async def test_restore_from_cache():
             ('+promoter.Sc_TDH3:crtE_WT:terminator.Sc_CYC1,+promoter.Sc_TDH3:crtYB_WT:terminator.Sc_CYC1,'
              '+promoter.Sc_TDH3:crtI_WT:terminator.Sc_CYC1')],
         'simulation-method': 'pfba',
-        'measurements': [{'unit': 'mmol', 'id': 'chebi:12965', 'measurements': [-1.1, -1.0], 'name': 'aldehydo-D-glucose'},
+        'measurements': [{'unit': 'mmol', 'id': 'chebi:12965', 'measurements': [-1.1, -1.0],
+                          'name': 'aldehydo-D-glucose', 'type': 'compound'},
                          {'unit': 'mmol', 'id': 'chebi:17579', 'measurements': [0.006, 0.008, 0.0065, 0.0007],
-                          'name': 'beta-carotene'},
-                         {'reaction_id': 'PFK', 'measurements': [5]}]
+                          'name': 'beta-carotene', 'type': 'compound'},
+                         {'id': 'PFK', 'measurements': [5], 'type': 'reaction'}]
     }
     model = await modify_model(message, (await restore_model(wild_type_id)).copy())
     db_key = await save_changes_to_db(model, wild_type_id, message)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,7 +20,8 @@ async def test_modify_model():
         'objectives': ['chebi:17790'],
         'genotype-changes': ['+Aac'],
         'medium': [{'id': 'chebi:44080', 'concentration': 0.01}],
-        'measurements': [{'id': 'chebi:44080', 'measurements': [-15, -11, -14, -12], 'unit': 'mg', 'name': 'glucose'}],
+        'measurements': [{'id': 'chebi:44080', 'measurements': [-15, -11, -14, -12], 'unit': 'mg', 'name': 'glucose'},
+                         {'reaction_id': 'PFK', 'measurements': [5, 5, 5, 5]}],
         'reactions-knockout': ['GLUDy', '3HAD160'],
     }
     assert await modify_model(message, (await restore_model('iJO1366')).copy())
@@ -58,7 +59,8 @@ async def test_restore_from_cache():
         'simulation-method': 'pfba',
         'measurements': [{'unit': 'mmol', 'id': 'chebi:12965', 'measurements': [-1.1, -1.0], 'name': 'aldehydo-D-glucose'},
                          {'unit': 'mmol', 'id': 'chebi:17579', 'measurements': [0.006, 0.008, 0.0065, 0.0007],
-                          'name': 'beta-carotene'}]
+                          'name': 'beta-carotene'},
+                         {'reaction_id': 'PFK', 'measurements': [5]}]
     }
     model = await modify_model(message, (await restore_model(wild_type_id)).copy())
     db_key = await save_changes_to_db(model, wild_type_id, message)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -42,7 +42,7 @@ async def test_save_and_restore():
     message = {
         GENOTYPE_CHANGES: [
             '-aceA -sucCD -pykA -pykF -pta +promoter.BBa_J23100:#AB326105:#NP_600058:terminator.BBa_0010'],
-        MEASUREMENTS: [{'id': 'chebi:44080', 'measurements': [0.01, float('nan')]}],
+        MEASUREMENTS: [{'id': 'chebi:44080', 'measurements': [0.01, float('nan')], 'type': 'compound'}],
         MEDIUM: [{'concentration': 27.0, 'id': 'chebi:42758'}, {'concentration': 6.0, 'id': 'chebi:16015'},
                  {'concentration': 1.6, 'id': 'chebi:30808'}, {'concentration': 2.0, 'id': 'chebi:35696'},
                  {'concentration': 1.0, 'id': 'chebi:49553'}, {'concentration': 2.0, 'id': 'chebi:49976'},
@@ -127,9 +127,9 @@ async def test_reactions_knockouts():
 
 def test_convert_measurements_to_mmol():
     ecoli = find_in_memory('iJO1366').copy()
-    measurements = [{'id': 'chebi:17790', 'measurements': [32.04186], 'unit': 'mg'}]
+    measurements = [{'id': 'chebi:17790', 'measurements': [32.04186], 'unit': 'mg', 'type': 'compound'}]
     assert convert_measurements_to_mmol(measurements, ecoli) == [
-        {'id': 'chebi:17790', 'measurements': [1.0], 'unit': 'mmol'}]
+        {'id': 'chebi:17790', 'measurements': [1.0], 'unit': 'mmol', 'type': 'compound'}]
 
 
 def test_add_reactions():


### PR DESCRIPTION
Support model modification and simulation when fluxes are measured for
specific reactions. When fluxes are requested for an infeasible model,
only return the measured fluxes.