### PR TITLE
feat: add reactions api

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -13,7 +13,10 @@ MESSAGE_FLUXES_INFEASIBLE = {'to-return': ['fluxes'], 'measurements': [
 MESSAGE_TMY_FLUXES = {'to-return': ['fluxes', 'tmy'], 'objectives': ['chebi:17790'], 'request-id': 'requestid'}
 MESSAGE_MODIFY = {
     'simulation-method': 'pfba',
-    'to-return': ['tmy', 'fluxes', 'model'],
+    "reactions-add": [
+        "MNXR81835", "MNXR83321"
+    ],
+    'to-return': ['tmy', 'fluxes', 'model', 'added-reactions', 'removed-reactions'],
     'objectives': ['chebi:17790'],
     'genotype-changes': ['+Aac', '-pta'],
     'measurements': MEASUREMENTS,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,8 +2,9 @@ import pytest
 from deepdiff import DeepDiff
 from model.app import (call_genes_to_reactions, modify_model, restore_model,
                        METHODS, Response, SIMULATION_METHOD, ProblemCache,
-                       restore_from_db, save_changes_to_db)
+                       restore_from_db, save_changes_to_db, find_in_memory, EMPTY_CHANGES, apply_reactions_add)
 from model.adapter import full_genotype
+from copy import deepcopy
 
 
 @pytest.mark.asyncio
@@ -11,6 +12,40 @@ async def test_call_genes_to_reactions():
     changes = full_genotype(['-aceA -sucCD +promoter.BBa_J23100:#AB326105:#NP_600058:terminator.BBa_0010'])
     result = await call_genes_to_reactions(changes)
     assert set(result.keys()) == {'BBa_J23100', 'AB326105', 'NP_600058', 'BBa_0010'}
+
+
+@pytest.mark.asyncio
+async def test_reactions_additions():
+    ecoli_original = find_in_memory('iJO1366').copy()
+    ecoli = ecoli_original.copy()
+    ecoli.notes['changes'] = deepcopy(EMPTY_CHANGES)
+    reaction_ids = {'MNXR69355', 'MNXR81835', 'MNXR83321'}
+    added_reactions = {'DM_12dgr182_9_12_e', 'DM_phitcoa_e', 'adapter_bzsuccoa_c_bzsuccoa_e',
+            'DM_mgdg182_9_12_e', 'adapter_mgdg182_9_12_c_mgdg182_9_12_e',
+            'adapter_phitcoa_c_phitcoa_e', 'DM_bzsuccoa_e',
+            'adapter_12dgr182_9_12_c_12dgr182_9_12_e'}
+    ecoli = await apply_reactions_add(ecoli, list(reaction_ids))
+    assert {i['id'] for i in ecoli.notes['changes']['added']['reactions']} - reaction_ids == added_reactions
+    for reaction in ecoli.notes['changes']['added']['reactions']:
+        assert ecoli.reactions.has_id(reaction['id'])
+    reaction_ids -= {'MNXR83321'}
+    ecoli = await apply_reactions_add(ecoli, list(reaction_ids))
+    assert {i['id'] for i in ecoli.notes['changes']['added']['reactions']} - reaction_ids == \
+           {'DM_phitcoa_e', 'adapter_bzsuccoa_c_bzsuccoa_e',
+            'adapter_phitcoa_c_phitcoa_e', 'DM_bzsuccoa_e'}
+    for reaction in ecoli.notes['changes']['added']['reactions']:
+        assert ecoli.reactions.has_id(reaction['id'])
+    removed_reactions = {'DM_12dgr182_9_12_e',
+            'DM_mgdg182_9_12_e', 'adapter_mgdg182_9_12_c_mgdg182_9_12_e',
+            'adapter_12dgr182_9_12_c_12dgr182_9_12_e'}
+    for reaction in removed_reactions:
+        assert not ecoli.reactions.has_id(reaction)
+    reaction_ids = {'MNXR69355', 'MNXR81835', 'MNXR83321'}
+    ecoli = await apply_reactions_add(ecoli, list(reaction_ids))
+    assert {i['id'] for i in ecoli.notes['changes']['added']['reactions']} - reaction_ids == added_reactions
+    reaction_ids = {}
+    ecoli = await apply_reactions_add(ecoli, list(reaction_ids))
+    assert ecoli.notes['changes']['added']['reactions'] == []
 
 
 @pytest.mark.asyncio
@@ -70,9 +105,9 @@ async def test_restore_from_cache():
     reactions = {
         r.id: dict(lower_bound=r.lower_bound, upper_bound=r.upper_bound)
         for r in model.reactions
-        }
+    }
     reactions_restored = {
         r.id: dict(lower_bound=r.lower_bound, upper_bound=r.upper_bound)
         for r in restored_model.reactions
-        }
+    }
     assert DeepDiff(reactions, reactions_restored) == {}

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -116,15 +116,15 @@ async def test_reactions_knockouts():
     reaction_ids = {'GLUDy', 'GLUDy', '3HAD160'}
     GLUDy_upper_bound = ecoli.reactions.get_by_id('GLUDy').upper_bound
     assert GLUDy_upper_bound != 0
-    ecoli = apply_reactions_knockouts(ecoli, list(reaction_ids))
+    ecoli = await apply_reactions_knockouts(ecoli, list(reaction_ids))
     assert set([i['id'] for i in ecoli.notes['changes']['removed']['reactions']]) == reaction_ids
     assert ecoli.reactions.get_by_id('GLUDy').upper_bound == 0
     reaction_ids = reaction_ids - {'GLUDy'}
-    ecoli = apply_reactions_knockouts(ecoli, list(reaction_ids))
+    ecoli = await apply_reactions_knockouts(ecoli, list(reaction_ids))
     assert set([i['id'] for i in ecoli.notes['changes']['removed']['reactions']]) == {'3HAD160'}
     assert GLUDy_upper_bound == ecoli.reactions.get_by_id('GLUDy').upper_bound
     reaction_ids = reaction_ids - {'3HAD160'}
-    ecoli = apply_reactions_knockouts(ecoli, list(reaction_ids))
+    ecoli = await apply_reactions_knockouts(ecoli, list(reaction_ids))
     assert set([i['id'] for i in ecoli.notes['changes']['removed']['reactions']]) == set()
     assert almost_equal(ecoli.optimize().objective_value, ecoli_original.optimize().objective_value)
 


### PR DESCRIPTION
accepts Metanetx ids
the same rules as with reaction-knockouts:
if reactions [A, B, C] sent with the first call, and reactions [A, B] sent with the second call, it's considered as if the action for the reaction C is reverted, in this case reaction C would be deleted from the model with all the new exchange/adapter reactions 