### PR TITLE
Feat/handle measured but missing reactions

### DIFF
--- a/model/adapter.py
+++ b/model/adapter.py
@@ -520,6 +520,7 @@ class MeasurementChangeModel(ModelModificationMixin):
         self.model = model
         self.changes = {
             'measured': {'reactions': set()},
+            'measured-missing': {'reactions': set()}
         }
         self.missing_in_model = []
 
@@ -558,7 +559,10 @@ class MeasurementChangeModel(ModelModificationMixin):
             elif scalar['type'] == 'reaction':
                 if scalar['db_name'] != 'BiGG':
                     raise NotImplementedError('only supporting bigg reaction identifiers not %s' % scalar['db_name'])
-                reaction = self.model.reactions.get_by_id(scalar['id'])
+                try:
+                    reaction = self.model.reactions.get_by_id(scalar['id'])
+                except KeyError:
+                    self.changes['measured-missing']['reactions'].add(Reaction(scalar['id']))
             else:
                 logger.info('scalar for measured type {} not supported'.format(scalar['type']))
             if reaction:

--- a/model/app.py
+++ b/model/app.py
@@ -94,6 +94,7 @@ OBJECTIVES = 'objectives'
 REQUEST_ID = 'request-id'
 REMOVED_REACTIONS = 'removed-reactions'
 ADDED_REACTIONS = 'added-reactions'
+MISSING_MEASURED_REACTIONS = 'missing-measured-reactions'
 
 EMPTY_CHANGES = {
     'added': {
@@ -105,6 +106,10 @@ EMPTY_CHANGES = {
         'reactions': [],
     },
     'measured': {
+        'genes': [],
+        'reactions': []
+    },
+    'measured-missing': {
         'genes': [],
         'reactions': []
     }
@@ -613,6 +618,11 @@ class Response(object):
     def growth_rate(self):
         return self.growth
 
+    def measured_missing_reactions(self):
+        return list(set(
+            [i['id'] for i in self.model.notes.get('changes', deepcopy(EMPTY_CHANGES))['measured-missing']['reactions']]
+        ))
+
     def removed_reactions(self):
         return list(set(
             [i['id'] for i in self.model.notes.get('changes', deepcopy(EMPTY_CHANGES))['removed']['reactions']]
@@ -640,6 +650,7 @@ RETURN_FUNCTIONS = {
     GROWTH_RATE: 'growth_rate',
     REMOVED_REACTIONS: 'removed_reactions',
     ADDED_REACTIONS: 'added_reactions',
+    MISSING_MEASURED_REACTIONS: 'measured_missing_reactions',
 }
 
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -6,7 +6,8 @@ MEASUREMENTS = [{'unit': 'mmol', 'name': 'aldehydo-D-glucose', 'id': 'chebi:4275
                  'type': 'compound'},
                 {'unit': 'mmol', 'name': 'ethanol', 'id': 'chebi:16236', 'measurements': [5.0, 4.8, 5.2, 4.9],
                  'type': 'compound'},
-                {'id': 'PFK', 'measurements': [5, 5], 'type': 'reaction', 'db_name': 'BiGG'}]
+                {'id': 'PFK', 'measurements': [5, 5], 'type': 'reaction', 'db_name': 'BiGG'},
+                {'id': 'BAD_ID', 'measurements': [5, 5], 'type': 'reaction', 'db_name': 'BiGG'}]
 MESSAGE_FLUXES = {'to-return': ['fluxes'], 'measurements': MEASUREMENTS}
 MESSAGE_FLUXES_INFEASIBLE = {'to-return': ['fluxes'], 'measurements': [
     {'id': 'ATPM', 'measurements': [100, 100], 'type': 'reaction', 'db_name': 'BiGG'}]}
@@ -46,6 +47,7 @@ def test_http():
             assert 'EX_etoh_e' in {rxn['id'] for rxn in changes['measured']['reactions']}
             assert 'PFK' in {rxn['id'] for rxn in changes['measured']['reactions']}
             assert 'b2297' in {rxn['id'] for rxn in changes['removed']['genes']}
+            assert 'BAD_ID' in {rxn['id'] for rxn in changes['measured-missing']['reactions']}
     response = requests.post(URL + 'iJO1366', json={'message': MESSAGE_FLUXES_INFEASIBLE})
     assert response.json()['fluxes']['ATPM'] == 100
     response = requests.post(URL + 'wrong_id', json={'message': {}})

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,9 +21,9 @@ async def test_reactions_additions():
     ecoli.notes['changes'] = deepcopy(EMPTY_CHANGES)
     reaction_ids = {'MNXR69355', 'MNXR81835', 'MNXR83321'}
     added_reactions = {'DM_12dgr182_9_12_e', 'DM_phitcoa_e', 'adapter_bzsuccoa_c_bzsuccoa_e',
-            'DM_mgdg182_9_12_e', 'adapter_mgdg182_9_12_c_mgdg182_9_12_e',
-            'adapter_phitcoa_c_phitcoa_e', 'DM_bzsuccoa_e',
-            'adapter_12dgr182_9_12_c_12dgr182_9_12_e'}
+                       'DM_mgdg182_9_12_e', 'adapter_mgdg182_9_12_c_mgdg182_9_12_e',
+                       'adapter_phitcoa_c_phitcoa_e', 'DM_bzsuccoa_e',
+                       'adapter_12dgr182_9_12_c_12dgr182_9_12_e'}
     ecoli = await apply_reactions_add(ecoli, list(reaction_ids))
     assert {i['id'] for i in ecoli.notes['changes']['added']['reactions']} - reaction_ids == added_reactions
     for reaction in ecoli.notes['changes']['added']['reactions']:
@@ -36,8 +36,8 @@ async def test_reactions_additions():
     for reaction in ecoli.notes['changes']['added']['reactions']:
         assert ecoli.reactions.has_id(reaction['id'])
     removed_reactions = {'DM_12dgr182_9_12_e',
-            'DM_mgdg182_9_12_e', 'adapter_mgdg182_9_12_c_mgdg182_9_12_e',
-            'adapter_12dgr182_9_12_c_12dgr182_9_12_e'}
+                         'DM_mgdg182_9_12_e', 'adapter_mgdg182_9_12_c_mgdg182_9_12_e',
+                         'adapter_12dgr182_9_12_c_12dgr182_9_12_e'}
     for reaction in removed_reactions:
         assert not ecoli.reactions.has_id(reaction)
     reaction_ids = {'MNXR69355', 'MNXR81835', 'MNXR83321'}


### PR DESCRIPTION
If flux has been measured for a reaction but user requests a model where that reaction is not defined, don't fail but record the identifier of the missing reaction and proceed.


