### PR TITLE
Add Raven

### DIFF
--- a/model/app.py
+++ b/model/app.py
@@ -4,13 +4,14 @@ from aiohttp import web
 import logging
 
 import model.handlers as handlers
+from .raven_middleware import raven_middleware
 
 
 LOGGER = logging.getLogger(__name__)
 
 
 def get_app():
-    app = web.Application()
+    app = web.Application(middlewares=[raven_middleware])
     app.router.add_route('GET', '/wsmodels/{model_id}', handlers.model_ws_full)
     app.router.add_route('GET', '/v1/wsmodels/{model_id}', handlers.model_ws_json_diff)
     app.router.add_route('GET', '/maps', handlers.maps)

--- a/model/raven_middleware.py
+++ b/model/raven_middleware.py
@@ -1,0 +1,26 @@
+import logging
+
+from aiohttp import web
+from raven import Client
+from raven.conf import setup_logging
+from raven.handlers.logging import SentryHandler
+
+from . import settings
+
+
+# Configure Raven to capture warning logs
+client = Client(settings.SENTRY_DSN)
+handler = SentryHandler(client)
+handler.setLevel(logging.WARNING)
+setup_logging(handler)
+
+
+async def raven_middleware(app, handler):
+    """aiohttp middleware captures any uncaught exceptions to Sentry before re-raising"""
+    async def middleware_handler(request):
+        try:
+            return await handler(request)
+        except Exception:
+            client.captureException()
+            raise
+    return middleware_handler

--- a/model/settings.py
+++ b/model/settings.py
@@ -3,3 +3,4 @@ import os
 
 ANNOTATIONS_API = os.environ['ANNOTATIONS_API']
 ID_MAPPER_API = os.environ['ID_MAPPER_API']
+SENTRY_DSN = os.environ.get('SENTRY_DSN', '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ pytest-cov==2.4.0
 aioredis==1.0
 deepdiff==1.0.0
 tqdm==4.19.4
+raven==6.3.0


### PR DESCRIPTION
- Adds python dependency `raven==6.3.0`
- Sends log events of `WARNING` or higher to Sentry
- Sends uncaught exceptions to Sentry by adding aiohttp middleware
- Messages are only sent when `SENTRY_DSN` is defined, so local dev env should not be affected