### PR TITLE
JWT validation PoC

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ID_MAPPER_API=${ID_MAPPER_API:-https://api.dd-decaf.eu/idmapping/query}
       - REDIS_ADDR=${REDIS_ADDR:-redis}
       - REDIS_PORT=${REDIS_PORT:-6379}
+      - JWT_PUBLIC_KEY_URL=http://${IAM_API}/.well-known/jwt-rs256.pub
       - ENV=dev
     volumes:
       - ./:/io

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import requests
 import sys
 
 from raven import Client
@@ -16,3 +17,13 @@ raven_client = Client(settings.SENTRY_DSN)
 handler = SentryHandler(raven_client)
 handler.setLevel(logging.WARNING)
 setup_logging(handler)
+
+# Retrieve JWT public key from authentication service
+try:
+    response = requests.get(settings.JWT_PUBLIC_KEY_URL)
+    response.raise_for_status()
+    settings.JWT_PUBLIC_KEY = response.body
+except requests.exceptions.RequestException:
+    logger.critical("Could not retrieve JWT public key from authentication service",
+                    exc_info=sys.exc_info())
+    raise

--- a/model/app.py
+++ b/model/app.py
@@ -4,14 +4,14 @@ from aiohttp import web
 import logging
 
 import model.handlers as handlers
-from .middleware import raven_middleware
+from .middleware import raven_middleware, auth_middleware
 
 
 LOGGER = logging.getLogger(__name__)
 
 
 def get_app():
-    app = web.Application(middlewares=[raven_middleware])
+    app = web.Application(middlewares=[raven_middleware, auth_middleware])
     app.router.add_route('GET', '/wsmodels/{model_id}', handlers.model_ws_full)
     app.router.add_route('GET', '/v1/wsmodels/{model_id}', handlers.model_ws_json_diff)
     app.router.add_route('GET', '/maps', handlers.maps)

--- a/model/handlers.py
+++ b/model/handlers.py
@@ -23,7 +23,7 @@ def require_role(role):
             if role not in request.jwt_token.get('roles', ()):
                 return web.json_response({
                     'code': 'unauthorized',
-                    'description': "Missing required role 'admin'",
+                    'description': "Missing required role '{}'".format(role),
                 }, status=401)
             return await f(request, *args, **kwargs)
         return wrapper

--- a/model/handlers.py
+++ b/model/handlers.py
@@ -24,7 +24,7 @@ def require_role(role):
                 return web.json_response({
                     'code': 'unauthorized',
                     'description': "Missing required role '{}'".format(role),
-                }, status=401)
+                }, status=403)
             return await f(request, *args, **kwargs)
         return wrapper
     return decorator

--- a/model/handlers.py
+++ b/model/handlers.py
@@ -3,6 +3,7 @@ from aiohttp import web, WSMsgType
 import json
 import logging
 import os
+from functools import wraps
 
 from cobra.io.dict import model_to_dict
 
@@ -14,6 +15,22 @@ from model.response import respond
 
 LOGGER = logging.getLogger(__name__)
 
+
+def require_role(role):
+    def decorator(f):
+        @wraps(f)
+        async def wrapper(request, *args, **kwargs):
+            if role not in request.jwt_token.get('roles', ()):
+                return web.json_response({
+                    'code': 'unauthorized',
+                    'description': "Missing required role 'admin'",
+                }, status=401)
+            return await f(request, *args, **kwargs)
+        return wrapper
+    return decorator
+
+
+@require_role('admin')
 async def model_ws_full(request):
     return await model_ws(request, False)
 

--- a/model/middleware.py
+++ b/model/middleware.py
@@ -26,7 +26,7 @@ async def auth_middleware(app, handler):
             decoded_token = jwt.decode(token, settings.get_jwt_public_key(), algorithms=['RS256'])
         except jwt.exceptions.InvalidTokenError:
             return web.json_response({
-                'code': 'unauthorized',
+                'code': 'unauthenticated',
                 'message': "Missing or invalid token",
             }, status=401)
         request.jwt_token = decoded_token

--- a/model/middleware.py
+++ b/model/middleware.py
@@ -1,6 +1,7 @@
 import logging
 
 from aiohttp import web
+import jwt
 
 from . import settings
 from . import raven_client
@@ -14,4 +15,20 @@ async def raven_middleware(app, handler):
         except Exception:
             raven_client.captureException()
             raise
+    return middleware_handler
+
+
+async def auth_middleware(app, handler):
+    """rejects the request if a valid token is not provided"""
+    async def middleware_handler(request):
+        token = request.headers.get('Authorization', '').replace('Bearer ', '')
+        try:
+            decoded_token = jwt.decode(token, settings.get_jwt_public_key(), algorithms=['RS256'])
+        except jwt.exceptions.InvalidTokenError:
+            return web.json_response({
+                'code': 'unauthorized',
+                'message': "Missing or invalid token",
+            }, status=401)
+        request.jwt_token = decoded_token
+        return await handler(request)
     return middleware_handler

--- a/model/settings.py
+++ b/model/settings.py
@@ -1,6 +1,11 @@
 import os
 
+import requests
+
 
 ANNOTATIONS_API = os.environ['ANNOTATIONS_API']
 ID_MAPPER_API = os.environ['ID_MAPPER_API']
 SENTRY_DSN = os.environ.get('SENTRY_DSN', '')
+
+JWT_PUBLIC_KEY = None  # note: will be assigned on init
+JWT_PUBLIC_KEY_URL = os.environ['JWT_PUBLIC_KEY_URL']

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ aioredis==1.0
 deepdiff==1.0.0
 tqdm==4.19.4
 raven==6.3.0
+pyjwt==1.5.3
+cryptography==2.1.4


### PR DESCRIPTION
**Proof of concept -- do not merge!**

1. On app init, the public key is downloaded from the configured IAM server
2. Middleware validates the token, rejects invalid tokens
3. Example `require_role` decorator validates a principal attribute structure with admin role claim

Notes:

- For anonymous users the middleware should be rewritten to accept requests with no token
- Possible key invalidation flows: e.g. if the token is invalid, fetch a new public key from IAM service and retry validation before rejecting the token
- Couldn't confirm if it's fine to add attributes (decoded `jwt_token`) to aiohttp request object like this
- Instead of a single keypair, we could use multiple, like https://www.googleapis.com/oauth2/v3/certs

### Added dependencies

[PyJWT](https://pyjwt.readthedocs.io/en/latest/)
[cryptography](https://pyjwt.readthedocs.io/en/latest/)