### PR TITLE
Switch solver from glpk to cplex

### DIFF
--- a/model/storage.py
+++ b/model/storage.py
@@ -70,6 +70,7 @@ async def save_changes_to_db(model, wild_type_id, message, version=None):
 
 def read_model(model_id):
     model = read_sbml_model(os.path.join(os.path.dirname(__file__), 'data', model_id + '.sbml.gz'))
+    model.solver = 'cplex'
     model.notes['namespace'] = constants.MODEL_NAMESPACE[model_id]
     return model
 


### PR DESCRIPTION
When loading a model through `read_sbml_model`, cameo [assumes lp and defaults to glpk](https://github.com/opencobra/cobrapy/blob/51cd74d13b60022537d46257235f400047f6dc55/cobra/util/solver.py#L179).