### PR TITLE
Patch optlang to avoid it overwriting root logger level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,11 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip install --upgrade --process-dependency-links -r /tmp/requirements.txt
 RUN pip freeze
 
+# FIXME: This ad-hoc patch is necessary to avoid optlang overriding our root logger level.
+# Hopefully, this will be included in an optlang release.
+# See https://github.com/biosustain/optlang/pull/162
+RUN sed -i "s/getLogger()/getLogger('cplex.problem')/" /usr/local/lib/python3.6/site-packages/optlang/cplex_interface.py
+
 COPY . "${CWD}/"
 
 CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8000", "-t", "150", "-k", "aiohttp.worker.GunicornWebWorker", "model.app:get_app()"]


### PR DESCRIPTION
This is the most straight-forward way I can see to circumvent the problem while waiting for an optlang release. The cplex interface is instantiated multiple times (when changing the solver, when copying a model, probably more) so simply reconfiguring logging explicitly after those operations seems more messy.