### PR TITLE
Add & expose metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To run all tests and QA checks, run `make qa`.
 
 Specify environment variables in a `.env` file. See `docker-compose.yml` for the possible variables and their default values.
 
-* `ENVIRONMENT` Set to either `development`, `testing`, or `production`
+* `ENVIRONMENT` Set to either `development`, `testing`, `staging` or `production`
 * `SENTRY_DSN` DSN for reporting exceptions to [Sentry](https://docs.sentry.io/clients/python/integrations/flask/).
 * `REDIS_ADDR` Local Redis service hostname
 * `REDIS_PORT` Local Redis service port

--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -57,21 +57,6 @@ spec:
             memory: "512Mi"
           limits:
             cpu: "100m"
-      - name: redis-exporter
-        image: oliver006/redis_exporter:latest
-        ports:
-        - containerPort: 9121
-        env:
-        - name: REDIS_ADDR
-          value: "localhost:6379"
-        - name: REDIS_ALIAS
-          value: model
-        resources:
-          requests:
-            cpu: "10m"
-            memory: "128Mi"
-          limits:
-            cpu: "100m"
       volumes:
       - name: prometheus-client
         emptyDir: {}
@@ -130,20 +115,6 @@ spec:
         image: redis:latest
         ports:
         - containerPort: 6379
-        resources:
-          requests:
-            cpu: "10m"
-          limits:
-            cpu: "100m"
-      - name: redis-exporter
-        image: oliver006/redis_exporter:latest
-        ports:
-        - containerPort: 9121
-        env:
-        - name: REDIS_ADDR
-          value: "localhost:6379"
-        - name: REDIS_ALIAS
-          value: model
         resources:
           requests:
             cpu: "10m"

--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -30,11 +30,16 @@ spec:
           value: http://gene-to-reactions-production/annotation/genes
         - name: ID_MAPPER_API
           value: http://id-mapper-production/idmapping/query
+        - name: prometheus_multiproc_dir
+          value: /prometheus-client
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
               name: model-production
               key: SENTRY_DSN
+        volumeMounts:
+        - mountPath: /prometheus-client
+          name: prometheus-client
         command: ["gunicorn", "-w", "4", "-b", "0.0.0.0:8000", "--preload", "-t", "30", "-k", "aiohttp.worker.GunicornWebWorker", "model.app:get_app()"]
         resources:
           requests:
@@ -67,6 +72,9 @@ spec:
             memory: "128Mi"
           limits:
             cpu: "100m"
+      volumes:
+      - name: prometheus-client
+        emptyDir: {}
 
 ---
 
@@ -102,11 +110,16 @@ spec:
           value: http://gene-to-reactions-staging/annotation/genes
         - name: ID_MAPPER_API
           value: http://id-mapper-production/idmapping/query
+        - name: prometheus_multiproc_dir
+          value: /prometheus-client
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
               name: model-staging
               key: SENTRY_DSN
+        volumeMounts:
+        - mountPath: /prometheus-client
+          name: prometheus-client
         command: ["gunicorn", "-w", "4", "-b", "0.0.0.0:8000", "--preload", "-t", "30", "-k", "aiohttp.worker.GunicornWebWorker", "model.app:get_app()"]
         resources:
           requests:
@@ -136,3 +149,6 @@ spec:
             cpu: "10m"
           limits:
             cpu: "100m"
+      volumes:
+      - name: prometheus-client
+        emptyDir: {}

--- a/deployment/service.yml
+++ b/deployment/service.yml
@@ -4,6 +4,8 @@ metadata:
   name: model-production
   annotations:
     prometheus.io/probe: "true"
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8000"
 spec:
   selector:
     app: model
@@ -22,6 +24,8 @@ metadata:
   name: model-staging
   annotations:
     prometheus.io/probe: "true"
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8000"
 spec:
   selector:
     app: model

--- a/deployment/service.yml
+++ b/deployment/service.yml
@@ -4,8 +4,6 @@ metadata:
   name: model-production
   annotations:
     prometheus.io/probe: "true"
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9121"
 spec:
   selector:
     app: model
@@ -15,10 +13,6 @@ spec:
     protocol: TCP
     port: 80
     targetPort: 8000
-  - name: redis-exporter
-    protocol: TCP
-    port: 9121
-    targetPort: 9121
 
 ---
 
@@ -28,8 +22,6 @@ metadata:
   name: model-staging
   annotations:
     prometheus.io/probe: "true"
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9121"
 spec:
   selector:
     app: model
@@ -39,7 +31,3 @@ spec:
     protocol: TCP
     port: 80
     targetPort: 8000
-  - name: redis-exporter
-    protocol: TCP
-    port: 9121
-    targetPort: 9121

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "3.2"
 services:
   web:
     build:
@@ -21,8 +21,11 @@ services:
       - REDIS_PORT=${REDIS_PORT:-6379}
       - ANNOTATIONS_API=${ANNOTATIONS_API:-https://api-staging.dd-decaf.eu/annotation/genes}
       - ID_MAPPER_API=${ID_MAPPER_API:-https://api.dd-decaf.eu/idmapping/query}
+      - prometheus_multiproc_dir=/prometheus-client
     volumes:
       - .:/app
+      - type: tmpfs
+        target: "/prometheus-client"
     command: gunicorn -c gunicorn.py model.app:get_app()
 
   redis:

--- a/gunicorn.py
+++ b/gunicorn.py
@@ -17,12 +17,19 @@
 
 import os
 
+from prometheus_client import multiprocess
+
+
 _config = os.environ["ENVIRONMENT"]
 
 bind = "0.0.0.0:8000"
 worker_class = "aiohttp.worker.GunicornWebWorker"
 timeout = 20
 accesslog = "-"
+
+
+def child_exit(server, worker):
+    multiprocess.mark_process_dead(worker.pid)
 
 
 if _config in ['production', 'staging']:

--- a/gunicorn.py
+++ b/gunicorn.py
@@ -25,11 +25,11 @@ timeout = 20
 accesslog = "-"
 
 
-if _config == "production":
+if _config in ['production', 'staging']:
     workers = os.cpu_count() * 2 + 1
     preload_app = True
     loglevel = "INFO"
-else:
+elif _config in ['testing', 'development']:
     workers = 1
     reload = True
     loglevel = "DEBUG"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ deepdiff==1.0.0
 tqdm==4.19.4
 raven==6.3.0
 yarl==1.1.1
+prometheus-client
 
 # Testing and QA
 codecov

--- a/src/model/app.py
+++ b/src/model/app.py
@@ -20,14 +20,14 @@ from aiohttp import web
 
 import model.handlers as handlers
 
-from .middleware import log_middleware, raven_middleware
+from .middleware import metrics_middleware, raven_middleware
 
 
 logger = logging.getLogger(__name__)
 
 
 def get_app():
-    app = web.Application(middlewares=[log_middleware, raven_middleware])
+    app = web.Application(middlewares=[metrics_middleware, raven_middleware])
     app.router.add_route('GET', '/wsmodels/{model_id}', handlers.model_ws_full)
     app.router.add_route('GET', '/v1/wsmodels/{model_id}', handlers.model_ws_json_diff)
     app.router.add_route('GET', '/maps', handlers.maps)

--- a/src/model/app.py
+++ b/src/model/app.py
@@ -37,6 +37,7 @@ def get_app():
     app.router.add_route('GET', '/v1/models/{model_id}', handlers.model_get)
     app.router.add_route('POST', '/v1/models/{model_id}', handlers.model_diff)
     app.router.add_route('GET', '/v1/model-info/{model_id}', handlers.model_info)
+    app.router.add_route('GET', '/metrics', handlers.metrics)
 
     # Configure default CORS settings.
     cors = aiohttp_cors.setup(app, defaults={

--- a/src/model/handlers.py
+++ b/src/model/handlers.py
@@ -19,7 +19,7 @@ import os
 
 from aiohttp import WSMsgType, web
 from cobra.io.dict import model_to_dict
-from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest, Histogram
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
 from prometheus_client.multiprocess import MultiProcessCollector
 
 import model.constants as constants

--- a/src/model/handlers.py
+++ b/src/model/handlers.py
@@ -19,6 +19,8 @@ import os
 
 from aiohttp import WSMsgType, web
 from cobra.io.dict import model_to_dict
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest, Histogram
+from prometheus_client.multiprocess import MultiProcessCollector
 
 import model.constants as constants
 from model.operations import modify_model
@@ -155,3 +157,8 @@ async def map(request):
     except FileNotFoundError:
         logger.debug(f"Request for unknown map: {modelId} / {mapId}")
         return web.HTTPNotFound()
+
+async def metrics(request):
+    resp = web.Response(body=generate_latest(MultiProcessCollector(CollectorRegistry())))
+    resp.content_type = CONTENT_TYPE_LATEST
+    return resp

--- a/src/model/handlers.py
+++ b/src/model/handlers.py
@@ -158,6 +158,7 @@ async def map(request):
         logger.debug(f"Request for unknown map: {modelId} / {mapId}")
         return web.HTTPNotFound()
 
+
 async def metrics(request):
     resp = web.Response(body=generate_latest(MultiProcessCollector(CollectorRegistry())))
     resp.content_type = CONTENT_TYPE_LATEST

--- a/src/model/metrics.py
+++ b/src/model/metrics.py
@@ -14,6 +14,17 @@
 
 import prometheus_client
 
+# REQUEST_TIME: Time spent waiting for outgoing API request to internal or external services
+# labels:
+#   service: The current service (always 'model')
+#   environment: The current runtime environment ('production' or 'staging')
+#   endpoint: The path to the requested endpoint without query parameters (e.g. '/models/iJO1366')
+REQUEST_TIME = prometheus_client.Histogram(
+    'decaf_request_handler_duration_seconds',
+    "Time spent in request",
+    ['service', 'environment', 'endpoint'])
+
+
 # API_REQUESTS: Time spent waiting for outgoing API request to internal or external services
 # labels:
 #   service: The current service (always 'model')

--- a/src/model/metrics.py
+++ b/src/model/metrics.py
@@ -1,0 +1,27 @@
+# Copyright 2018 Novo Nordisk Foundation Center for Biosustainability, DTU.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import prometheus_client
+
+# API_REQUESTS: Time spent waiting for outgoing API request to internal or external services
+# labels:
+#   service: The current service (always 'model')
+#   environment: The current runtime environment ('production' or 'staging')
+#   api_name: A short name for the API service (e.g. 'gene-to-reactions')
+#   endpoint: The full URL to the external API (e.g.
+#             'http://gene-to-reactions/annotations/genes')
+API_REQUESTS = prometheus_client.Histogram(
+    'decaf_api_request_duration_seconds',
+    "Time spent waiting for outgoing API request to internal or external services",
+    ['service', 'environment', 'api_name', 'endpoint'])

--- a/src/model/metrics.py
+++ b/src/model/metrics.py
@@ -14,6 +14,7 @@
 
 import prometheus_client
 
+
 # REQUEST_TIME: Time spent waiting for outgoing API request to internal or external services
 # labels:
 #   service: The current service (always 'model')

--- a/src/model/middleware.py
+++ b/src/model/middleware.py
@@ -14,17 +14,19 @@
 
 import logging
 
-from . import raven_client
+from . import raven_client, settings
+from .metrics import REQUEST_TIME
 
 
 logger = logging.getLogger(__name__)
 
 
-async def log_middleware(app, handler):
-    """Log all initiated requests"""
+async def metrics_middleware(app, handler):
+    """Log and time all initiated requests"""
     async def middleware_handler(request):
         logger.debug(f"Handling request: {request.url.relative()}")
-        return await handler(request)
+        with REQUEST_TIME.labels('model', settings.ENVIRONMENT, request.url.path).time():
+            return await handler(request)
     return middleware_handler
 
 

--- a/src/model/settings.py
+++ b/src/model/settings.py
@@ -16,6 +16,8 @@ import os
 
 
 ENVIRONMENT = os.environ['ENVIRONMENT']
+assert ENVIRONMENT in ('production', 'staging', 'testing', 'development')
+
 ANNOTATIONS_API = os.environ['ANNOTATIONS_API']
 ID_MAPPER_API = os.environ['ID_MAPPER_API']
 SENTRY_DSN = os.environ.get('SENTRY_DSN', '')

--- a/src/model/storage.py
+++ b/src/model/storage.py
@@ -102,7 +102,7 @@ def preload_cache():
             Models.get_dict(model_id)
 
 
-if settings.ENVIRONMENT == 'production':
+if settings.ENVIRONMENT in ['production', 'staging']:
     preload_cache()
 
 


### PR DESCRIPTION
- Record time spent in all request handlers, seperated by request path
- Record API calls (to gene-to-reactions and id-mapper)
- Expose metrics at `/metrics` to be scraped by prometheus