### PR TITLE
Replace gene-to-reactions with direct ICE queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,7 @@ Specify environment variables in a `.env` file. See `docker-compose.yml` for the
 * `SENTRY_DSN` DSN for reporting exceptions to [Sentry](https://docs.sentry.io/clients/python/integrations/flask/).
 * `REDIS_ADDR` Local Redis service hostname
 * `REDIS_PORT` Local Redis service port
-* `ANNOTATIONS_API` URL to the annotations service
+* `ICE_API` ICE API endpoint
+* `ICE_USERNAME` ICE username
+* `ICE_PASSWORD` ICE password
 * `ID_MAPPER_API` URL to the ID mapper service

--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -27,8 +27,18 @@ spec:
           value: localhost
         - name: REDIS_PORT
           value: "6379"
-        - name: ANNOTATIONS_API
-          value: http://gene-to-reactions-production/annotation/genes
+        - name: ICE_API
+          value: https://ice.dd-decaf.eu
+        - name: ICE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: model-production
+              key: ICE_USERNAME
+        - name: ICE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: model-production
+              key: ICE_PASSWORD
         - name: ID_MAPPER_API
           value: http://id-mapper-production/idmapping/query
         - name: prometheus_multiproc_dir
@@ -93,8 +103,18 @@ spec:
           value: localhost
         - name: REDIS_PORT
           value: "6379"
-        - name: ANNOTATIONS_API
-          value: http://gene-to-reactions-staging/annotation/genes
+        - name: ICE_API
+          value: https://ice.dd-decaf.eu
+        - name: ICE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: model-production
+              key: ICE_USERNAME
+        - name: ICE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: model-production
+              key: ICE_PASSWORD
         - name: ID_MAPPER_API
           value: http://id-mapper-production/idmapping/query
         - name: prometheus_multiproc_dir

--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -108,12 +108,12 @@ spec:
         - name: ICE_USERNAME
           valueFrom:
             secretKeyRef:
-              name: model-production
+              name: model-staging
               key: ICE_USERNAME
         - name: ICE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: model-production
+              name: model-staging
               key: ICE_PASSWORD
         - name: ID_MAPPER_API
           value: http://id-mapper-production/idmapping/query

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,9 @@ services:
       - ENVIRONMENT=development
       - REDIS_ADDR=${REDIS_ADDR:-redis}
       - REDIS_PORT=${REDIS_PORT:-6379}
-      - ANNOTATIONS_API=${ANNOTATIONS_API:-https://api-staging.dd-decaf.eu/gene-to-reactions/annotation/genes}
+      - ICE_API=${ICE_API:-https://ice.dd-decaf.eu}
+      - ICE_USERNAME=${ICE_USERNAME}
+      - ICE_PASSWORD=${ICE_PASSWORD}
       - ID_MAPPER_API=${ID_MAPPER_API:-https://api.dd-decaf.eu/idmapping/query}
       - prometheus_multiproc_dir=/prometheus-client
     volumes:

--- a/src/model/adapter.py
+++ b/src/model/adapter.py
@@ -20,7 +20,6 @@ import os
 import re
 from collections import defaultdict
 
-import aiohttp
 import gnomic
 import networkx as nx
 import numpy as np
@@ -29,6 +28,7 @@ from cameo.data import metanetx
 from cobra import Metabolite, Reaction
 from cobra.manipulation import find_gene_knockout_reactions
 
+import aiohttp
 from model import constants
 from model.driven import adjust_fluxes2model
 from model.metrics import API_REQUESTS

--- a/src/model/app.py
+++ b/src/model/app.py
@@ -16,9 +16,8 @@ import asyncio
 import logging
 
 import aiohttp_cors
-from aiohttp import web
-
 import model.handlers as handlers
+from aiohttp import web
 
 from .middleware import metrics_middleware, raven_middleware
 

--- a/src/model/handlers.py
+++ b/src/model/handlers.py
@@ -17,12 +17,12 @@ import json
 import logging
 import os
 
-from aiohttp import WSMsgType, web
 from cobra.io.dict import model_to_dict
 from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
 from prometheus_client.multiprocess import MultiProcessCollector
 
 import model.constants as constants
+from aiohttp import WSMsgType, web
 from model.operations import modify_model
 from model.response import respond
 from model.storage import (

--- a/src/model/ice_client.py
+++ b/src/model/ice_client.py
@@ -18,16 +18,14 @@ import logging
 import requests
 
 from . import settings
+from .utils import Singleton
 
 
 logger = logging.getLogger(__name__)
 
 
-class _ICE:
-    """
-    ICE API client. Don't instantiate this class; import the `ice` singleton from the same module.
-    Docs: http://ice.jbei.org/api/index.html
-    """
+class ICE(metaclass=Singleton):
+    """ICE API client. Docs: http://ice.jbei.org/api/index.html"""
 
     def __init__(self):
         """On instantiation, request and store a session id for later use."""
@@ -72,7 +70,3 @@ class _ICE:
         if add_session_id:
             headers.update({'X-ICE-Authentication-SessionId': self.SESSION_ID})
         return headers
-
-
-# Singleton instance of the ice client - import and use this instance
-ice = _ICE()

--- a/src/model/ice_client.py
+++ b/src/model/ice_client.py
@@ -1,0 +1,77 @@
+# Copyright 2018 Novo Nordisk Foundation Center for Biosustainability, DTU.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import requests
+
+from . import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class _ICE:
+    """
+    ICE API client. Don't instantiate this class; import the `ice` singleton from the same module.
+    Docs: http://ice.jbei.org/api/index.html
+    """
+
+    def __init__(self):
+        """On instantiation, request and store a session id for later use."""
+        self._update_session_id()
+
+    def get_reaction_equations(self, genotype):
+        """Request genotype part info from ICE and return reaction map information from the references field."""
+        logger.info(f"Requesting genotype '{genotype}' from ICE")
+        response = requests.get(f"{settings.ICE_API}/rest/parts/{genotype}", headers=self._headers())
+
+        # In case of authentication failure, get a new session id and re-try the request. The ICE documentation says
+        # nothing about access token expiry, so it's not clear whether this can or will ever occur.
+        if response.status_code in (401, 403):
+            self._update_session_id()
+            response = requests.get(f"{settings.ICE_API}/rest/parts/{genotype}", headers=self._headers())
+
+        # If the part is not found, return an empty response
+        if response.status_code == 404:
+            return {}
+
+        response.raise_for_status()
+        result = response.json()
+
+        # Extract reaction id -> string map from the expected format in the references field
+        reactions = result['references'].split(',')
+        reaction_tuples = [reaction.split(':') for reaction in reactions]
+        reactions_map = {id.strip(): string.strip() for id, string in reaction_tuples}
+        return reactions_map
+
+    def _update_session_id(self):
+        """Query ICE for a new access token. Note that this usually takes ~10 seconds!"""
+        logger.info("Requesting session token from ICE")
+        response = requests.post(f"{settings.ICE_API}/rest/accesstokens",
+                                 headers=self._headers(add_session_id=False),
+                                 data=json.dumps({'email': settings.ICE_USERNAME, 'password': settings.ICE_PASSWORD}))
+        response.raise_for_status()
+        self.SESSION_ID = response.json()['sessionId']
+
+    def _headers(self, add_session_id=True):
+        """Return headers dict for use with ICE API requests."""
+        headers = {'Content-Type': 'application/json'}
+        if add_session_id:
+            headers.update({'X-ICE-Authentication-SessionId': self.SESSION_ID})
+        return headers
+
+
+# Singleton instance of the ice client - import and use this instance
+ice = _ICE()

--- a/src/model/ice_client.py
+++ b/src/model/ice_client.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+
 import requests
 
 from . import settings

--- a/src/model/operations.py
+++ b/src/model/operations.py
@@ -202,7 +202,7 @@ async def apply_reactions_knockouts(model, reactions_ids):
     return await operate_on_reactions(model, reactions_ids, 'removed', knockout_apply, restore_bounds)
 
 
-async def call_genes_to_reactions(genotype_features):
+async def get_genotype_reactions(genotype_features):
     """Make series of calls for getting information about which reactions were added with new genes
 
     :param genotype_features: generator of new genes ids
@@ -226,7 +226,7 @@ async def apply_genotype_changes(model, genotype_changes):
     """
     logger.info('Genotype changes %s', genotype_changes)
     genotype_features = full_genotype(genotype_changes)
-    genes_to_reactions = await call_genes_to_reactions(genotype_features)
+    genes_to_reactions = await get_genotype_reactions(genotype_features)
     logger.info('Genes to reaction: %s', genes_to_reactions)
     change_model = GenotypeChangeModel(model, genotype_features, genes_to_reactions, model.notes['namespace'])
     await change_model.map_metabolites()

--- a/src/model/operations.py
+++ b/src/model/operations.py
@@ -29,7 +29,6 @@ from model.adapter import (
     get_unique_metabolite)
 from model.ice_client import ice
 from model.metrics import API_REQUESTS
-from model.utils import log_time
 
 
 logger = logging.getLogger(__name__)

--- a/src/model/operations.py
+++ b/src/model/operations.py
@@ -27,11 +27,12 @@ from model import settings
 from model.adapter import (
     GenotypeChangeModel, MeasurementChangeModel, MediumChangeModel, NoIDMapping, feature_id, full_genotype,
     get_unique_metabolite)
-from model.ice_client import ice
+from model.ice_client import ICE
 from model.metrics import API_REQUESTS
 
 
 logger = logging.getLogger(__name__)
+ice = ICE()
 
 
 async def operate_on_reactions(model, reactions, key, apply_function, undo_function):

--- a/src/model/settings.py
+++ b/src/model/settings.py
@@ -18,7 +18,9 @@ import os
 ENVIRONMENT = os.environ['ENVIRONMENT']
 assert ENVIRONMENT in ('production', 'staging', 'testing', 'development')
 
-ANNOTATIONS_API = os.environ['ANNOTATIONS_API']
+ICE_API = os.environ['ICE_API']
+ICE_USERNAME = os.environ['ICE_USERNAME']
+ICE_PASSWORD = os.environ['ICE_PASSWORD']
 ID_MAPPER_API = os.environ['ID_MAPPER_API']
 SENTRY_DSN = os.environ.get('SENTRY_DSN', '')
 

--- a/src/model/storage.py
+++ b/src/model/storage.py
@@ -19,9 +19,9 @@ import logging
 import os
 from functools import lru_cache
 
-import aioredis
 from cobra.io import model_to_dict, read_sbml_model
 
+import aioredis
 from model import constants, settings
 from model.operations import restore_changes
 from model.utils import log_time

--- a/src/model/utils.py
+++ b/src/model/utils.py
@@ -21,6 +21,15 @@ from functools import wraps
 logger = logging.getLogger(__name__)
 
 
+class Singleton(type):
+    """Implement the singleton pattern by using this type as metaclass"""
+    _instances = {}
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
 def timing(f):
     @wraps(f)
     def wrap(*args, **kwargs):

--- a/src/model/utils.py
+++ b/src/model/utils.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 class Singleton(type):
     """Implement the singleton pattern by using this type as metaclass"""
     _instances = {}
+
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
             cls._instances[cls] = super().__call__(*args, **kwargs)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -14,11 +14,11 @@
 
 from copy import deepcopy
 
-import aiohttp
 import jsonpatch
 import pytest
-from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 
+import aiohttp
+from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 from model.app import get_app
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,15 +17,15 @@ from deepdiff import DeepDiff
 
 from model.adapter import full_genotype
 from model.constants import METHODS, SIMULATION_METHOD, get_empty_changes
-from model.operations import apply_reactions_add, call_genes_to_reactions, modify_model
+from model.operations import apply_reactions_add, get_genotype_reactions, modify_model
 from model.response import Response
 from model.storage import Models, restore_from_db, restore_model, save_changes_to_db
 
 
 @pytest.mark.asyncio
-async def test_call_genes_to_reactions():
+async def test_get_genotype_reactions():
     changes = full_genotype(['-aceA -sucCD +promoter.BBa_J23100:#AB326105:#NP_600058:terminator.BBa_0010'])
-    result = await call_genes_to_reactions(changes)
+    result = await get_genotype_reactions(changes)
     assert set(result.keys()) == {'BBa_J23100', 'AB326105', 'NP_600058', 'BBa_0010'}
 
 


### PR DESCRIPTION
The biggest problem with the slow queries was that the call to `/rest/accesstokens` takes about 10 seconds. In this rewrite, the access token is now queried on service startup and used for subsequent queries.

The [ICE API docs](http://ice.jbei.org/api/index.html) don't mention anything about expiry time, so I added a safeguard which, if any query returns status 401/403, a new access token is fetched.

Note also that these calls are synchronous now (which was also the case with ice-communications)