### PR TITLE
Create unknown metabolites

### DIFF
--- a/src/model/operations.py
+++ b/src/model/operations.py
@@ -14,6 +14,7 @@
 
 import logging
 
+from cobra import Metabolite
 from cobra.io.dict import reaction_from_dict
 
 
@@ -37,6 +38,11 @@ def apply_operations(model, operations):
 
 def _add_reaction(model, data):
     logger.debug(f"Adding reaction to model '{model.id}' from: {data}")
+    # Ensure all reaction metabolites exist in the model (adding existing metabolites is silently ignored).
+    # Note: Assuming the reaction occurs in the cytosol compartment, but this might be overridable by the user in the
+    # future.
+    metabolites = [Metabolite(id, compartment='c') for id in data['metabolites'].keys()]
+    model.add_metabolites(metabolites)
     reaction = reaction_from_dict(data, model)
     model.add_reactions([reaction])
 

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -40,6 +40,29 @@ def test_add_reaction(e_coli_core):
     assert e_coli_core.reactions.FOOBAR.bounds == (0.0, 1000.0)
 
 
+def test_add_reaction_unknown_metabolites(e_coli_core):
+    e_coli_core, biomass_reaction = e_coli_core
+    assert not e_coli_core.metabolites.has_id('foo_c')
+    assert not e_coli_core.metabolites.has_id('bar_c')
+    apply_operations(e_coli_core, [{
+        'operation': "add",
+        'type': "reaction",
+        'data': {
+            'id': 'FOOBAR',
+            'name': 'Foo Bar',
+            'metabolites': {
+                'foo_c': -1.0,
+                'bar_c': 1.0,
+            },
+            'lower_bound': -1000.0,
+            'upper_bound': 1000.0,
+            'gene_reaction_rule': '',
+        }
+    }])
+    assert e_coli_core.metabolites.has_id('foo_c')
+    assert e_coli_core.metabolites.has_id('bar_c')
+
+
 def test_modify_reaction(e_coli_core):
     e_coli_core, biomass_reaction = e_coli_core
     assert e_coli_core.reactions.CS.bounds == (0.0, 1000.0)


### PR DESCRIPTION
When adding reactions to a model, if it contains metabolite ids unknown to the model, they will now be created first instead of raising an error.