### PR TITLE
Authorization handling

### DIFF
--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -33,6 +33,8 @@ spec:
           value: https://api.dd-decaf.eu/mstorage
         - name: ICE_API
           value: https://ice.dd-decaf.eu
+        - name: IAM_API
+          value: https://api.dd-decaf.eu/iam
         - name: ICE_USERNAME
           valueFrom:
             secretKeyRef:
@@ -118,6 +120,8 @@ spec:
           value: https://api-staging.dd-decaf.eu/mstorage
         - name: ICE_API
           value: https://ice.dd-decaf.eu
+        - name: IAM_API
+          value: https://api-staging.dd-decaf.eu/iam
         - name: ICE_USERNAME
           valueFrom:
             secretKeyRef:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - REDIS_ADDR=${REDIS_ADDR:-redis}
       - REDIS_PORT=${REDIS_PORT:-6379}
       - ICE_API=${ICE_API:-https://ice.dd-decaf.eu}
+      - IAM_API=${IAM_API:-https://api-staging.dd-decaf.eu/iam}
       - ICE_USERNAME=${ICE_USERNAME}
       - ICE_PASSWORD=${ICE_PASSWORD}
       - ID_MAPPER_API=${ID_MAPPER_API:-https://api.dd-decaf.eu/idmapping/query}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ gunicorn
 tqdm
 raven[flask]
 prometheus-client
+python-jose
 
 # Testing and QA
 codecov

--- a/src/model/app.py
+++ b/src/model/app.py
@@ -22,6 +22,7 @@ from flask_cors import CORS
 from raven.contrib.flask import Sentry
 from werkzeug.contrib.fixers import ProxyFix
 
+from model import jwt
 from model.settings import Settings
 
 
@@ -44,6 +45,9 @@ def init_app(application, interface):
         sentry = Sentry(dsn=application.config['SENTRY_DSN'], logging=True,
                         level=logging.WARNING)
         sentry.init_app(application)
+
+    # Add JWT handlers
+    jwt.init_app(application)
 
     # Add routes and resources.
     # TODO: use flask-apispec

--- a/src/model/jwt.py
+++ b/src/model/jwt.py
@@ -1,0 +1,116 @@
+# Copyright 2018 Novo Nordisk Foundation Center for Biosustainability, DTU.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Handling and verification of JWT claims."""
+
+import logging
+from functools import wraps
+
+from flask import abort, g, request
+from jose import jwt
+
+
+logger = logging.getLogger(__name__)
+
+
+def init_app(app):
+    """Add the jwt decoding middleware to the app."""
+    @app.before_request
+    def decode_jwt():
+        if 'Authorization' not in request.headers:
+            logger.debug("No JWT provided")
+            g.jwt_valid = False
+            g.jwt_claims = {'prj': {}}
+            return
+
+        auth = request.headers['Authorization']
+        if not auth.startswith('Bearer '):
+            g.jwt_valid = False
+            g.jwt_claims = {'prj': {}}
+            return
+
+        try:
+            _, token = auth.split(' ', 1)
+            g.jwt_claims = jwt.decode(
+                token,
+                app.config['JWT_PUBLIC_KEY'],
+                app.config['JWT_PUBLIC_KEY']['alg'])
+            # JSON object names can only be strings. Map project ids to ints for
+            # easier handling
+            g.jwt_claims['prj'] = {
+                int(key): value
+                for key, value in g.jwt_claims['prj'].items()
+            }
+            g.jwt_valid = True
+            g.jwt_token = token
+            logger.debug(f"JWT claims accepted: {g.jwt_claims}")
+        except (jwt.JWTError, jwt.ExpiredSignatureError,
+                jwt.JWTClaimsError) as e:
+            abort(401, f"JWT authentication failed: {e}")
+
+
+def jwt_required(function):
+    """
+    Require JWT to be provided.
+
+    Use this as a decorator for endpoints requiring JWT to be provided.
+    """
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        if not g.jwt_valid:
+            abort(401, "JWT authentication required")
+        return function(*args, **kwargs)
+    return wrapper
+
+
+def jwt_require_claim(project_id, required_level):
+    """
+    Require a JWT claim for the given project and access level.
+
+    Verify that the current user has access to the given project id, and that
+    their access level is equal to or higher than the given required level.
+    Aborts the request if the user does not have sufficient access.
+
+    :param project_id: The project ID to verify access for
+    :param required_level: The required access level (admin, write or read)
+    :return: None
+    """
+    ACCESS_LEVELS = {
+        'admin': 3,
+        'write': 2,
+        'read': 1,
+    }
+
+    if required_level not in ACCESS_LEVELS.keys():
+        raise ValueError(f"Invalid claim level '{required_level}'")
+
+    logger.debug(f"Looking for '{required_level}' access to project "
+                 f"'{project_id}' in claims '{g.jwt_claims}'")
+
+    # Nobody can write to public projects
+    if project_id is None and required_level != 'read':
+        abort(403, "Public data can not be modified")
+
+    try:
+        claim_level = g.jwt_claims['prj'][project_id]
+    except KeyError:
+        # The given project id is not included in the users claims
+        abort(403, "You do not have access to the requested resource")
+
+    # The given project id is included in the claims; verify that the access
+    # level is sufficient
+    if ACCESS_LEVELS[claim_level] < ACCESS_LEVELS[required_level]:
+        abort(403,
+              f"This operation requires access level '{required_level}', your "
+              f"access level is '{claim_level}'")

--- a/src/model/settings.py
+++ b/src/model/settings.py
@@ -14,6 +14,8 @@
 
 import os
 
+import requests
+
 
 class Settings:
     ENVIRONMENT = os.environ['ENVIRONMENT']
@@ -27,6 +29,7 @@ class Settings:
     SENTRY_DSN = os.environ.get('SENTRY_DSN', '')
     REDIS_ADDR = os.environ['REDIS_ADDR']
     REDIS_PORT = os.environ['REDIS_PORT']
+    JWT_PUBLIC_KEY = requests.get(f"{os.environ['IAM_API']}/keys").json()["keys"][0]
 
     LOGGING = {
         'version': 1,

--- a/src/model/storage.py
+++ b/src/model/storage.py
@@ -20,6 +20,7 @@ from flask import g
 
 from model.app import app
 from model.exceptions import Forbidden, ModelNotFound, Unauthorized
+from model.jwt import jwt_require_claim
 
 
 logger = logging.getLogger(__name__)
@@ -59,7 +60,11 @@ def get(model_id):
     """Return a ModelWrapper instance for the given model id"""
     if model_id not in _MODELS:
         _load_model(model_id)
-    return _MODELS[model_id]
+    wrapper = _MODELS[model_id]
+    # Enforce access control for non-public cached models.
+    if wrapper.project_id is not None:
+        jwt_require_claim(wrapper.project_id, 'read')
+    return wrapper
 
 
 def preload_public_models():

--- a/src/model/storage.py
+++ b/src/model/storage.py
@@ -28,12 +28,14 @@ logger = logging.getLogger(__name__)
 class ModelWrapper:
     """A wrapper for a cobrapy model with some additional metadata."""
 
-    def __init__(self, model, organism_id, biomass_reaction):
+    def __init__(self, model, project_id, organism_id, biomass_reaction):
         """
         Parameters
         ----------
         model: cobra.Model
             A cobrapy model instance.
+        project_id: int
+            Reference to the project id to which this model belongs, or None if it is a public model.
         organism_id: str
             A reference to the organism for which the given model belongs. The identifier is internal to the DD-DeCaF
             platform and references the `id` field in https://api.dd-decaf.eu/warehouse/organisms.
@@ -43,6 +45,7 @@ class ModelWrapper:
         self.model = model
         # Use the cplex solver for performance
         self.model.solver = 'cplex'
+        self.project_id = project_id
         self.organism_id = organism_id
         self.biomass_reaction = biomass_reaction
 
@@ -91,6 +94,7 @@ def _load_model(model_id):
     model_data = response.json()
     _MODELS[model_id] = ModelWrapper(
         model_from_dict(model_data['model_serialized']),
+        model_data['project_id'],
         model_data['organism_id'],
         model_data['default_biomass_reaction'],
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def models():
                                                                'BIOMASS_Ecoli_core_w_GAM')
     model = read_sbml_model('tests/data/e_coli_core.sbml.gz')
     storage._MODELS['test_e_coli_core_proprietary'] = storage.ModelWrapper(model, 1, "Escherichia coli",
-                                                               'BIOMASS_Ecoli_core_w_GAM')
+                                                                           'BIOMASS_Ecoli_core_w_GAM')
     model = read_sbml_model('tests/data/iJO1366.sbml.gz')
     storage._MODELS['test_iJO1366'] = storage.ModelWrapper(model, None, "Escherichia coli",
                                                            'BIOMASS_Ec_iJO1366_core_53p95M')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,9 @@ def models():
     model = read_sbml_model('tests/data/e_coli_core.sbml.gz')
     storage._MODELS['test_e_coli_core'] = storage.ModelWrapper(model, None, "Escherichia coli",
                                                                'BIOMASS_Ecoli_core_w_GAM')
+    model = read_sbml_model('tests/data/e_coli_core.sbml.gz')
+    storage._MODELS['test_e_coli_core_proprietary'] = storage.ModelWrapper(model, 1, "Escherichia coli",
+                                                               'BIOMASS_Ecoli_core_w_GAM')
     model = read_sbml_model('tests/data/iJO1366.sbml.gz')
     storage._MODELS['test_iJO1366'] = storage.ModelWrapper(model, None, "Escherichia coli",
                                                            'BIOMASS_Ec_iJO1366_core_53p95M')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,8 @@ from model.app import init_app
 def app():
     """Provide the initialized Flask app"""
     init_app(app_, None)
-    return app_
+    with app_.app_context():
+        yield app_
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,9 +43,11 @@ def models():
     models.
     """
     model = read_sbml_model('tests/data/e_coli_core.sbml.gz')
-    storage._MODELS['test_e_coli_core'] = storage.ModelWrapper(model, "Escherichia coli", 'BIOMASS_Ecoli_core_w_GAM')
+    storage._MODELS['test_e_coli_core'] = storage.ModelWrapper(model, None, "Escherichia coli",
+                                                               'BIOMASS_Ecoli_core_w_GAM')
     model = read_sbml_model('tests/data/iJO1366.sbml.gz')
-    storage._MODELS['test_iJO1366'] = storage.ModelWrapper(model, "Escherichia coli", 'BIOMASS_Ec_iJO1366_core_53p95M')
+    storage._MODELS['test_iJO1366'] = storage.ModelWrapper(model, None, "Escherichia coli",
+                                                           'BIOMASS_Ec_iJO1366_core_53p95M')
     return storage._MODELS
 
 

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -32,6 +32,11 @@ def test_simulate_wrong_id(client):
     assert response.status_code == 404
 
 
+def test_simulate_unauthorized(client, models):
+    response = client.post("/simulate", json={'model_id': 'test_e_coli_core_proprietary'})
+    assert response.status_code == 403
+
+
 def test_simulate_no_operations(client, models):
     response = client.post("/simulate", json={'model_id': 'test_iJO1366'})
     assert response.status_code == 200


### PR DESCRIPTION
- Read and validate provided JWT
- Forward JWT to model-storage service in order to get access to models
- Enforce access control for cached proprietary models (simulating a model requires read access to its related project)