### PR TITLE
Use sync gunicorn workers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ test = pytest
 
 [tool:pytest]
 testpaths = tests
+filterwarnings =
+   ignore::DeprecationWarning:libsbml
 
 [isort]
 line_length = 120

--- a/src/model/resources.py
+++ b/src/model/resources.py
@@ -97,7 +97,7 @@ def model_modify(model_id):
         if errors:
             # If any errors occured during modifications, discard generated operations and return the error messages to
             # the client for follow-up
-            return jsonify({'errors': errors})
+            return jsonify({'errors': errors}), 400
         else:
             delta_id = deltas.save(model.id, conditions, operations)
             return jsonify({'id': delta_id, 'operations': operations})

--- a/src/model/resources.py
+++ b/src/model/resources.py
@@ -86,14 +86,17 @@ def model_modify(model_id):
             errors.extend(errors_genotype)
 
         if 'measurements' in conditions:
-            operations_measurements, errors_measurements = adapt_from_measurements(model, model_wrapper.biomass_reaction,
-                                                                                conditions['measurements'])
+            operations_measurements, errors_measurements = adapt_from_measurements(
+                model,
+                model_wrapper.biomass_reaction,
+                conditions['measurements'],
+            )
             operations.extend(operations_measurements)
             errors.extend(errors_measurements)
 
         if errors:
-            # If any errors occured during modifications, discard generated operations and return the error messages to the
-            # client for follow-up
+            # If any errors occured during modifications, discard generated operations and return the error messages to
+            # the client for follow-up
             return jsonify({'errors': errors})
         else:
             delta_id = deltas.save(model.id, conditions, operations)


### PR DESCRIPTION
This ensures that cached model instances are bound to a single request at a time and hence the context manager can be used to undo modifications. This avoids the copy operations and should speed up modification and simulation requests substantially.