### PR TITLE
Various fixes in data adapters

### DIFF
--- a/src/model/modeling/adapter.py
+++ b/src/model/modeling/adapter.py
@@ -19,6 +19,7 @@ from collections import namedtuple
 import numpy as np
 from cobra import Reaction
 from cobra.io.dict import reaction_to_dict
+from cobra.medium.boundary_types import find_external_compartment
 
 from model.exceptions import MetaboliteNotFound, PartNotFound, ReactionNotFound
 from model.ice_client import ICE
@@ -100,10 +101,12 @@ def apply_medium(model, medium):
     medium_mapping = {}
     for compound in medium:
         try:
-            metabolite = find_metabolite(model, compound.id, compound.namespace, 'e')
+            extracellular = find_external_compartment(model)
+            metabolite = find_metabolite(model, compound.id, compound.namespace, extracellular)
         except MetaboliteNotFound:
             warning = (
-                f"Cannot add medium compund '{compound.id}' - metabolite not found in extracellular compartment"
+                f"Cannot add medium compund '{compound.id}' - metabolite not found in extracellular compartment "
+                f"'{extracellular}'"
             )
             warnings.append(warning)
             logger.warning(warning)

--- a/src/model/modeling/cobra_helpers.py
+++ b/src/model/modeling/cobra_helpers.py
@@ -22,16 +22,18 @@ logger = logging.getLogger(__name__)
 
 def find_reaction(model, id, namespace):
     """
-    Search for a given reaction in the model, also searching in annotations.
+    Search a model for a given reaction, also looking in annotations.
 
     Parameters
     ----------
     model: cobra.Model
     id: str
-        The identifier of the reaction to find.
+        The identifier of the reaction to find. The comparison is made case
+        insensitively.
     namespace: str
         The miriam namespace identifier in which the given metabolite is
         registered. See https://www.ebi.ac.uk/miriam/main/collections
+        The comparison is made case insensitively.
 
     Returns
     -------
@@ -46,24 +48,10 @@ def find_reaction(model, id, namespace):
         If no reactions are found for the given parameters.
     """
     def query_fun(reaction):
-        # Match namespace and identifiers case-insensitively
-        for model_namespace, model_ids in reaction.annotation.items():
-            if namespace.lower() != model_namespace.lower():
-                return False
-            if isinstance(model_ids, list):
-                return id.lower() in [i.lower() for i in model_ids]
-            else:
-                return id.lower() == model_ids.lower()
+        return _query_item(reaction, id, namespace)
 
     reactions = model.reactions.query(query_fun)
     if len(reactions) == 0:
-        # No annotated result, try the default namespace (without confirming the
-        # namespace id).
-        try:
-            return model.reactions.get_by_id(id)
-        except KeyError:
-            pass
-
         raise ReactionNotFound(
             f"Could not find reaction {id} in namespace {namespace} for "
             f"model {model.id}"
@@ -76,18 +64,21 @@ def find_reaction(model, id, namespace):
 
 def find_metabolite(model, id, namespace, compartment):
     """
-    Search for a given metabolite in the model, also searching in annotations.
+    Search a model for a given metabolite, also looking in annotations.
 
     Parameters
     ----------
     model: cobra.Model
     id: str
-        The identifier of the metabolite to find, e.g. "CHEBI:12965". Note that
-        BiGG identifiers (in namespace "bigg.metabolite") should NOT include a
-        compartment postfix, e.g., use "o2" and not "o2_e".
+        The identifier of the metabolite to find, e.g. "CHEBI:12965". The
+        comparison is made case insensitively. If a match is not found, another
+        attempt will be made with the compartment id appended, e.g., looking for
+        both "o2" and "o2_e". However, the caller should ideally pass the full
+        metabolite identifier.
     namespace: str
         The miriam namespace identifier in which the given metabolite is
         registered. See https://www.ebi.ac.uk/miriam/main/collections
+        The comparison is made case insensitively.
     compartment: str
         The compartment in which to look for the metabolite.
 
@@ -103,49 +94,66 @@ def find_metabolite(model, id, namespace, compartment):
     MetaboliteNotFound
         If no metabolites are found for the given parameters.
     """
-    # Add compartment postfix to metabolites in the BiGG namespace.
-    if namespace == "bigg.metabolite":
-        for model_compartment in model.compartments:
-            if id.endswith(f"_{model_compartment}"):
-                logger.warning(
-                    f"BiGG metabolite {id} seems to already include a "
-                    f"compartment postfix. Compartment {compartment} will be "
-                    f"appended anyway, searching for {id}_{compartment}."
-                )
-        id = f"{id}_{compartment}"
-
     def query_fun(metabolite):
         if metabolite.compartment != compartment:
             return False
 
-        # Try to find a case insensitive match for the namespace key
-        for met_namespace in metabolite.annotation:
-            if namespace.lower() == met_namespace.lower():
-                identifier = metabolite.annotation[met_namespace]
-                # Compare the identifier case insensitively as well
-                # Annotations may contain a single id or a list of ids
-                if isinstance(identifier, list):
-                    return id.lower() in [i.lower() for i in identifier]
-                else:
-                    return id.lower() == identifier.lower()
-        return False
+        result = _query_item(metabolite, id, namespace)
+        if result:
+            return result
+
+        # If the original query fails, retry with the compartment id appended
+        # to the identifier (a regular convenation with BiGG metabolites, but
+        # may also be the case in other namespaces).
+        return _query_item(metabolite, f"{id}_{compartment}", namespace)
 
     metabolites = model.metabolites.query(query_fun)
     if len(metabolites) == 0:
-        # No annotated result, try the default namespace (without confirming the
-        # namespace id).
-        try:
-            metabolite = model.metabolites.get_by_id(id)
-            if metabolite.compartment == compartment:
-                return metabolite
-        except KeyError:
-            pass
-
         raise MetaboliteNotFound(
-            f"Could not find metabolite {id} in namespace {namespace} and "
-            f"compartment {compartment} for model {model.id}"
+            f"Could not find metabolite {id} or {id}_{compartment} in "
+            f"namespace {namespace} and compartment {compartment} for model "
+            f"{model.id}"
         )
     elif len(metabolites) > 1:
         raise IndexError(f"Expected single metabolite, found {metabolites}")
     else:
         return metabolites[0]
+
+
+def _query_item(item, query_id, query_namespace):
+    """
+    Check if the given cobra collection item matches the query arguments.
+
+    Parameters
+    ----------
+    item: cobra.Reaction or cobra.Metabolite
+    query_id: str
+        The identifier to compare. The comparison is made case insensitively.
+    query_namespace: str
+        The miriam namespace identifier in which the given metabolite is
+        registered. See https://www.ebi.ac.uk/miriam/main/collections
+        The comparison is made case insensitively.
+
+    Returns
+    -------
+    bool
+        True if the given id exists in the default namespace, or in the model
+        annotations by the queried namespace, otherwise False.
+    """
+    # Try the default identifiers (without confirming the namespace)
+    if query_id.lower() == item.id.lower():
+        return True
+
+    # Otherwise, try to find a case insensitive match for the namespace key
+    for namespace in item.annotation:
+        if query_namespace.lower() == namespace.lower():
+            annotation = item.annotation[namespace]
+            # Compare the identifier case insensitively as well
+            # Annotations may contain a single id or a list of ids
+            if isinstance(annotation, list):
+                if query_id.lower() in [i.lower() for i in annotation]:
+                    return True
+            else:
+                if query_id.lower() == annotation.lower():
+                    return True
+    return False

--- a/src/model/modeling/cobra_helpers.py
+++ b/src/model/modeling/cobra_helpers.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from model.exceptions import MetaboliteNotFound, ReactionNotFound
+
+
+logger = logging.getLogger(__name__)
 
 
 def find_reaction(model, id, namespace):
@@ -69,7 +74,7 @@ def find_reaction(model, id, namespace):
         return reactions[0]
 
 
-def find_metabolite(model, id, namespace, compartment='e'):
+def find_metabolite(model, id, namespace, compartment):
     """
     Search for a given metabolite in the model, also searching in annotations.
 
@@ -82,8 +87,7 @@ def find_metabolite(model, id, namespace, compartment='e'):
         The miriam namespace identifier in which the given metabolite is
         registered. See https://www.ebi.ac.uk/miriam/main/collections
     compartment: str
-        The compartment in which to look for the metabolite. Defaults to the
-        extracellular compartment.
+        The compartment in which to look for the metabolite.
 
     Returns
     -------

--- a/src/model/modeling/cobra_helpers.py
+++ b/src/model/modeling/cobra_helpers.py
@@ -105,7 +105,7 @@ def find_metabolite(model, id, namespace, compartment):
     """
     # Add compartment postfix to metabolites in the BiGG namespace.
     if namespace == "bigg.metabolite":
-        for model_compartment in model.compartments.keys():
+        for model_compartment in model.compartments:
             if id.endswith(f"_{model_compartment}"):
                 logger.warning(
                     f"BiGG metabolite {id} seems to already include a "

--- a/src/model/modeling/cobra_helpers.py
+++ b/src/model/modeling/cobra_helpers.py
@@ -82,7 +82,9 @@ def find_metabolite(model, id, namespace, compartment):
     ----------
     model: cobra.Model
     id: str
-        The identifier of the metabolite to find, e.g. "CHEBI:12965".
+        The identifier of the metabolite to find, e.g. "CHEBI:12965". Note that
+        BiGG identifiers (in namespace "bigg.metabolite") should NOT include a
+        compartment postfix, e.g., use "o2" and not "o2_e".
     namespace: str
         The miriam namespace identifier in which the given metabolite is
         registered. See https://www.ebi.ac.uk/miriam/main/collections
@@ -101,6 +103,17 @@ def find_metabolite(model, id, namespace, compartment):
     MetaboliteNotFound
         If no metabolites are found for the given parameters.
     """
+    # Add compartment postfix to metabolites in the BiGG namespace.
+    if namespace == "bigg.metabolite":
+        for model_compartment in model.compartments.keys():
+            if id.endswith(f"_{model_compartment}"):
+                logger.warning(
+                    f"BiGG metabolite {id} seems to already include a "
+                    f"compartment postfix. Compartment {compartment} will be "
+                    f"appended anyway, searching for {id}_{compartment}."
+                )
+        id = f"{id}_{compartment}"
+
     def query_fun(metabolite):
         if metabolite.compartment != compartment:
             return False

--- a/src/model/modeling/driven.py
+++ b/src/model/modeling/driven.py
@@ -41,7 +41,10 @@ def minimize_distance(model, biomass_reaction, growth_rate, measurements):
     # TODO (Ali Kaafarani): Support for uncertainties or multiple observations
     if len(growth_rate['measurements']) != 1:
         raise NotImplementedError("Cannot handle multiple growth rate measurements yet")
-    model.reactions.get_by_id(biomass_reaction).bounds = (growth_rate['measurements'][0], growth_rate['measurements'][0])
+    model.reactions.get_by_id(biomass_reaction).bounds = (
+        growth_rate['measurements'][0],
+        growth_rate['measurements'][0]
+    )
 
     for measure in [m for m in measurements if m['type'] == 'reaction']:
         index.append(measure['id'])

--- a/src/model/modeling/driven.py
+++ b/src/model/modeling/driven.py
@@ -41,10 +41,10 @@ def minimize_distance(model, biomass_reaction, growth_rate, measurements):
     # TODO (Ali Kaafarani): Support for uncertainties or multiple observations
     if len(growth_rate['measurements']) != 1:
         raise NotImplementedError("Cannot handle multiple growth rate measurements yet")
-    model.reactions.get_by_id(biomass_reaction).bounds = (
-        growth_rate['measurements'][0],
-        growth_rate['measurements'][0]
-    )
+    # Until uncertainties are specified in the dataset, allow for ~5% deviation
+    lower_bound = growth_rate['measurements'][0] * 0.95
+    upper_bound = growth_rate['measurements'][0] * 1.05
+    model.reactions.get_by_id(biomass_reaction).bounds = (lower_bound, upper_bound)
 
     for measure in [m for m in measurements if m['type'] == 'reaction']:
         index.append(measure['id'])

--- a/src/model/modeling/driven.py
+++ b/src/model/modeling/driven.py
@@ -34,11 +34,14 @@ def minimize_distance(model, biomass_reaction, growth_rate, measurements):
     if not growth_rate:
         raise ValueError("Expected measurements to contain an objective "
                          "constraint as measured growth rate")
-    # Include the growth rate in measurements
-    index.append(biomass_reaction)
-    observations.append(np.nanmean(growth_rate['measurements']))
-    uncertainties.append(np.nanstd(growth_rate['measurements'], ddof=1)
-                         if len(growth_rate['measurements']) >= 3 else 1)
+
+    # Trust the growth rate over the measurements. Meaning, constrain the
+    # biomass reaction to the observed values instead of simply including it in
+    # the measurements to be minimized.
+    # TODO (Ali Kaafarani): Support for uncertainties or multiple observations
+    if len(growth_rate['measurements']) != 1:
+        raise NotImplementedError("Cannot handle multiple growth rate measurements yet")
+    model.reactions.get_by_id(biomass_reaction).bounds = (growth_rate['measurements'][0], growth_rate['measurements'][0])
 
     for measure in [m for m in measurements if m['type'] == 'reaction']:
         index.append(measure['id'])

--- a/src/model/resources.py
+++ b/src/model/resources.py
@@ -45,7 +45,7 @@ def init_app(app):
 
 
 @use_kwargs(ModificationRequest)
-def model_modify(model_id, medium, genotype, measurements):
+def model_modify(model_id, medium, genotype, growth_rate, measurements):
     if not request.is_json:
         abort(415, "Non-JSON request content is not supported")
 
@@ -76,8 +76,8 @@ def model_modify(model_id, medium, genotype, measurements):
             warnings.extend(results[1])
             errors.extend(results[2])
 
-        if measurements:
-            results = apply_measurements(model, model_wrapper.biomass_reaction, measurements)
+        if growth_rate or measurements:
+            results = apply_measurements(model, model_wrapper.biomass_reaction, growth_rate, measurements)
             operations.extend(results[0])
             warnings.extend(results[1])
             errors.extend(results[2])

--- a/src/model/schemas.py
+++ b/src/model/schemas.py
@@ -49,9 +49,15 @@ class Measurement(Schema):
     type = fields.String(required=True, validate=OneOf([
         'compound',
         'reaction',
-        'growth-rate',
         'protein',
     ]))
+
+    class Meta:
+        strict = True
+
+
+class GrowthRate(Schema):
+    measurements = fields.List(fields.Float())
 
     class Meta:
         strict = True
@@ -60,6 +66,7 @@ class Measurement(Schema):
 class ModificationRequest(Schema):
     medium = fields.Nested(MediumCompound, many=True, missing=None)
     genotype = fields.Function(deserialize=full_genotype, missing=None)
+    growth_rate = fields.Nested(GrowthRate, missing=None)
     measurements = fields.Nested(Measurement, many=True, missing=None)
 
     class Meta:

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -60,6 +60,6 @@ def test_measurements_adapter(iJO1366):
         {'type': 'reaction', 'id': 'PFK', 'namespace': "bigg.reaction", 'measurements': [5, 4.8, 7]},
         {'type': 'reaction', 'id': 'PGK', 'namespace': "bigg.reaction", 'measurements': [5, 5]},
     ]
-    operations, warnings, errors = apply_measurements(iJO1366, biomass_reaction, measurements)
+    operations, warnings, errors = apply_measurements(iJO1366, biomass_reaction, None, measurements)
     assert len(operations) == 4
     assert len(errors) == 0

--- a/tests/unit/test_cobra_helpers.py
+++ b/tests/unit/test_cobra_helpers.py
@@ -20,7 +20,9 @@ from model.modeling.cobra_helpers import find_metabolite
 
 def test_existing_metabolite(iJO1366):
     iJO1366, biomass_reaction = iJO1366
-    assert find_metabolite(iJO1366, 'CHEBI:17790', 'chebi', 'e') == find_metabolite(iJO1366, 'meoh', 'bigg.metabolite', 'e')
+    metabolite_chebi = find_metabolite(iJO1366, 'CHEBI:17790', 'chebi', 'e')
+    metabolite_bigg = find_metabolite(iJO1366, 'meoh', 'bigg.metabolite', 'e')
+    assert metabolite_chebi == metabolite_bigg
     assert find_metabolite(iJO1366, 'succ', 'bigg.metabolite', 'e').formula == 'C4H4O4'
     with pytest.raises(MetaboliteNotFound):
         find_metabolite(iJO1366, 'wrong_id', 'wrong_namespace', 'e')

--- a/tests/unit/test_cobra_helpers.py
+++ b/tests/unit/test_cobra_helpers.py
@@ -20,7 +20,7 @@ from model.modeling.cobra_helpers import find_metabolite
 
 def test_existing_metabolite(iJO1366):
     iJO1366, biomass_reaction = iJO1366
-    assert find_metabolite(iJO1366, 'CHEBI:17790', 'chebi') == find_metabolite(iJO1366, 'meoh', 'bigg.metabolite')
-    assert find_metabolite(iJO1366, 'succ', 'bigg.metabolite').formula == 'C4H4O4'
+    assert find_metabolite(iJO1366, 'CHEBI:17790', 'chebi', 'e') == find_metabolite(iJO1366, 'meoh', 'bigg.metabolite', 'e')
+    assert find_metabolite(iJO1366, 'succ', 'bigg.metabolite', 'e').formula == 'C4H4O4'
     with pytest.raises(MetaboliteNotFound):
-        find_metabolite(iJO1366, 'wrong_id', 'wrong_namespace')
+        find_metabolite(iJO1366, 'wrong_id', 'wrong_namespace', 'e')

--- a/tests/unit/test_driven.py
+++ b/tests/unit/test_driven.py
@@ -28,7 +28,7 @@ def test_minimize_distance_no_growth_rate(iJO1366):
             'namespace': 'bigg.reaction',
             'measurements': [2.36, 2.45, 1.92]
         }]
-        minimize_distance(iJO1366, biomass_reaction, measurements)
+        minimize_distance(iJO1366, biomass_reaction, None, measurements)
 
 
 def test_adjust_fluxes2model(iJO1366):


### PR DESCRIPTION
- Use `cobra.medium.boundary_types.find_external_compartment` to specify the extracellular compartment
- Postfix bigg metabolite identifiers with `_compartment` when looking up metabolites by id
- Update measurements schema, keeping growth rate separate from other fluxomics
- Constrain the model with observed growth rate, instead of including it as a measurement, when minimizing distance to observed fluxes