### PR TITLE
feat: limit cobra logs to warnings

### DIFF
--- a/src/model/settings.py
+++ b/src/model/settings.py
@@ -87,6 +87,10 @@ class Default:
                 # All loggers will by default use the root logger below (and
                 # hence be very verbose). To silence spammy/uninteresting log
                 # output, add the loggers here and increase the loglevel.
+                'cobra': {
+                    'level': 'WARNING',
+                    'handlers': ['console'],
+                }
             },
             'root': {
                 'level': 'DEBUG',


### PR DESCRIPTION
With the merge of https://github.com/opencobra/cobrapy/pull/774, it becomes clear that the log output from cobra is a bit too verbose. Hopefully limiting levels to warning+ shouldn't hide any relevant information during development.